### PR TITLE
specファイルのslugキーが文字列だった場合、プラグイン情報の取得に失敗します

### DIFF
--- a/core.rb
+++ b/core.rb
@@ -10,6 +10,14 @@ module Packaged
 end
 
 module Packaged::Common
+  extend self
+
+  # specファイルの内容について、扱いやすいように値を加工する
+  def spec_normalization(spec)
+    spec = YAML.load(spec) if spec.is_a? String
+    spec["slug".freeze] = spec["slug".freeze].to_sym
+    spec
+  end
 end
 
 module Packaged::GUI
@@ -39,7 +47,7 @@ module Packaged::Local
           fp.read
         }
 
-        result = YAML.load(yaml_str)
+        result = Packaged::Common::spec_normalization(yaml_str)
         break
       end
     }
@@ -72,7 +80,7 @@ module Packaged::Local
 
     spec = Packaged::Local::get_spec(extracted_dir)
 
-    FileUtils.mv(extracted_dir, File.join(plugin_dir, spec["slug"].to_s)) 
+    FileUtils.mv(extracted_dir, File.join(plugin_dir, spec["slug"].to_s))
   end
 
   # インストールされたプラグインの情報を取得する
@@ -248,8 +256,7 @@ module Packaged::Remote
 
     [".mikutter.yml", "spec"].each { |path|
       begin
-        result = YAML.load(get_file(user_name, repo_name, "master", path))
-        
+        result = Packaged::Common::spec_normalization(get_file(user_name, repo_name, "master", path))
         break
       rescue
         # 例外は無視


### PR DESCRIPTION
specファイルのslugがStringになっているものがある時に、一定条件で確実にクラッシュします。
原因は、プラグインのspecを探すときに、単にspec['slug']とSymbolと比較するようになっていたことです(StringとSymbolは内容が同じでも一致しないため探索に失敗する)。

プラグイン情報を扱う場合、slugがStringで嬉しいことは何もないと思うので、読み込み時に変換するようにしました。Packaged::Commonに入れていいのか、とか、いろいろ適当にやってるのでいい感じに修正してください。

なお、この問題が再現したプラグインは、 mikutter-aclog (https://github.com/rhenium/mikutter_aclog.git) です。これがインストールされていると起動はしますが、このプラグインをクリックしたらクラッシュします。
