### PR TITLE
インストール画面のユーザ検索をEnterキーで実行

### DIFF
--- a/install_dialog.rb
+++ b/install_dialog.rb
@@ -70,6 +70,9 @@ module Packaged::GUI::Install
     widgets[:user_label].text = "GitHubユーザ名"
 
     widgets[:user_text] = Gtk::Entry.new
+    widgets[:user_text].signal_connect(:activate) {
+      widgets[:search_button].clicked
+    }
 
     widgets[:search_button] = Gtk::Button.new
     widgets[:search_button].label = "リポジトリ検索"


### PR DESCRIPTION
インストール画面のユーザ名入力欄で、Enterキーで即座に検索を実行できれば便利かと思いましたので実装しました。
