### PR TITLE
`spec` がファイルでない場合に起動出来ない

### DIFF
--- a/core.rb
+++ b/core.rb
@@ -87,7 +87,7 @@ module Packaged::Local
     [".mikutter.yml", "spec"].each { |path|
       file = File.join(dir, path)
 
-      if File.exist?(file)
+      if File.file?(file)
         yaml_str = File.open(file) { |fp|
           fp.read
         }


### PR DESCRIPTION
ユニットテスト用のディレクトリ (`spec`) を掘れるようにする
